### PR TITLE
Remove install instructions that do not install our customized version

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -2,14 +2,6 @@
 
 **Note:** Due to the USB 3.0 translation layer between native hardware and virtual machine, the *librealsense* team does not recommend or support installation in a VM.
 
-## Install pre-built snap
-
-Install librealsense in seconds on [Ubuntu and other snap supported Linux distributions](https://snapcraft.io/docs/core/install) with:
-
-    snap install librealsense
-
-Snaps contain all necessary dependencies required to run. The snap will get automatically updated when a new version is pushed to the store. 
-
 ## 3rd-party dependencies
 
 The project requires two external dependencies, *glfw* and *libusb-1.0*. The Cmake build environment additionally requires *pkg-config*.

--- a/doc/installation_osx.md
+++ b/doc/installation_osx.md
@@ -1,27 +1,15 @@
-# Apple OSX Installation  
+# Apple OSX Installation
 
 **Note:** Due to the USB 3.0 translation layer between native hardware and virtual machine, the librealsense team does not recommend or support installation in a VM.
 
 The simplest method of installation uses the [Homebrew package manager](http://brew.sh/). First install [Homebrew](http://brew.sh/) via terminal and confirm it's working with ```$ brew doctor```
-
-## Installation via Homebrew
-
-To install librealsense, you can then install either the latest release of librealsense:
-
-    $ brew install librealsense
-
-Or you can install the head version from GitHub:
-
-    $ brew install librealsense --HEAD
-
-To install with examples, add the ```--with-examples``` flag. Use ```$ brew info librealsense``` to retrieve the location of the installation.
 
 ## Installation from source
 
 If you would like to compile librealsense from source:
 
     $ brew install cmake pkg-config libusb glfw
-    $ git clone https://github.com/IntelRealSense/librealsense.git
+    $ git clone https://github.com/pupil-labs/librealsense.git
     $ cd librealsense
     $ mkdir build && cd build
 


### PR DESCRIPTION
- Removed `snap` install instructions for Linux
- Removed `homebrew` install instructions for macOS